### PR TITLE
update unhold to resume

### DIFF
--- a/doc/features.md
+++ b/doc/features.md
@@ -6,7 +6,7 @@
   --end \<call>                 End call
   --decline \<call>             Decline call
   --hold \<call>                Hold call
-  --unhold \<call>              Resume call
+  --resume \<call>              Resume call
   --list-audio-devices          List audio input and output devices
   --set-input \<device-index>   Set active input audio device
   --set-output \<device-index>  Set active output audio device

--- a/doc/features.md
+++ b/doc/features.md
@@ -6,7 +6,7 @@
   --end \<call>                 End call
   --decline \<call>             Decline call
   --hold \<call>                Hold call
-  --unhold \<call>              Unhold call
+  --unhold \<call>              Resume call
   --list-audio-devices          List audio input and output devices
   --set-input \<device-index>   Set active input audio device
   --set-output \<device-index>  Set active output audio device

--- a/doc/testplan.md
+++ b/doc/testplan.md
@@ -29,6 +29,6 @@ jamictrl.py --call $alice
 call=$(jamictrl.py --get-call-list)
 jamictrl.py --accept $call
 jamictrl.py --hold $call
-jamictrl.py --unhold $call
+jamictrl.py --resume $call
 jamictrl.py --end $call
 ```

--- a/jamictrl/controller.py
+++ b/jamictrl/controller.py
@@ -1,10 +1,6 @@
 #! /usr/bin/env python3
 #
-#  Copyright (C) 2004-2025 Savoir-faire Linux Inc. Inc
-#
-# Author: Guillaume Roguez <guillaume.roguez@savoirfairelinux.com>
-#
-# Contributor: Jean-Charles de Longueville <jean-charles@de-longueville.eu>
+# Copyright (C) 2004-2025 Savoir-faire Linux Inc. Inc
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -800,12 +796,12 @@ class libjamiCtrl(Thread):
         self.callmanager.hold(self.account, callid)
 
 
-    def UnHold(self, callid):
+    def Resume(self, callid):
         """
         Use the current account previously set using setAccount().
         If no account specified, first registered one in account list is used.
 
-        Unhold an incoming call identified by a CallID
+        Resume call identified by a CallID
         """
 
         # Set the account to be used for this call
@@ -819,7 +815,7 @@ class libjamiCtrl(Thread):
         if callid is None or callid == "":
             raise libjamiCtrlError("Invalid callID")
 
-        self.callmanager.unhold(self.account, callid)
+        self.callmanager.resume(self.account, callid)
 
     def SetAudioOutputDevice(self, index):
         self.configurationmanager.setAudioOutputDevice(int (index ))

--- a/jamictrl/jamictrl.py
+++ b/jamictrl/jamictrl.py
@@ -91,8 +91,8 @@ if __name__ == "__main__":
     group.add_argument('--decline', help='Decline call', metavar='<call>')
 
     group = parser.add_mutually_exclusive_group()
-    group.add_argument('--hold', help='Hold the call', metavar='<call>')
-    group.add_argument('--unhold', help='Unhold the call', metavar='<call>')
+    group.add_argument('--hold', help='Hold call', metavar='<call>')
+    group.add_argument('--resume', help='Resume call', metavar='<call>')
 
     parser.add_argument('--list-audio-devices', help='List audio input and output devices', action='store_true')
     parser.add_argument('--set-input', help='Set active input audio device',
@@ -203,8 +203,8 @@ if __name__ == "__main__":
     if args.hold:
         ctrl.Hold(args.hold)
 
-    if args.unhold:
-        ctrl.UnHold(args.unhold)
+    if args.resume:
+        ctrl.Resume(args.resume)
 
     if args.list_audio_devices:
         allDevices = ctrl.ListAudioDevices()

--- a/jamictrl/tester.py
+++ b/jamictrl/tester.py
@@ -150,8 +150,8 @@ class libjamiTester():
         print("Holding: " + callId)
         ctrl.Hold(callId)
         time.sleep(delay)
-        print("UnHolding: " + callId)
-        ctrl.UnHold(callId)
+        print("Resuming: " + callId)
+        ctrl.Resume(callId)
 
 #
 # tests
@@ -187,7 +187,7 @@ class libjamiTester():
 
 # testLoopCallDhtWithHold
 # perform <nbIteration> DHT calls using <delay> between each call
-# perform stress hold/unhold between each call
+# perform stress hold/resume between each call
 
     def testLoopCallDhtWithHold(self, ctrl, nbIteration, delay):
         print("**[BEGIN] DHT call test with hold")


### PR DESCRIPTION
The following definition at the https://www.thefreedictionary.com/unhold page seems to relate to `End call` and `Transfer call`.
> To cease to hold; to unhand; to release.

This patch updates `Unhold call` to `Resume call`.

GitLab: https://git.jami.net/savoirfairelinux/jami-daemon/-/issues/1154